### PR TITLE
Demonstrate use of startWithAppId

### DIFF
--- a/CustomInvitationSample/CustomInvitationSample/AppDelegate.m
+++ b/CustomInvitationSample/CustomInvitationSample/AppDelegate.m
@@ -21,7 +21,6 @@
 - (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions {
     [EXPCore setDebugLogEnabled:YES];
     [EXPCore setEventLogEnabled:NO];
-    [EXPCore start];
     
     // capture and log SDK lifecycle events;
     // active for all examples

--- a/CustomInvitationSample/CustomInvitationSample/Base.lproj/Main.storyboard
+++ b/CustomInvitationSample/CustomInvitationSample/Base.lproj/Main.storyboard
@@ -3,7 +3,7 @@
     <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="22684"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="22685"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -355,6 +355,7 @@
                     </view>
                     <navigationItem key="navigationItem" id="zRd-Bp-x45"/>
                     <connections>
+                        <outlet property="showSurveyButton" destination="AaC-ED-62L" id="IB8-kh-aaB"/>
                         <outlet property="textView" destination="VFA-hP-F22" id="vbh-H1-tOJ"/>
                     </connections>
                 </viewController>

--- a/CustomInvitationSample/CustomInvitationSample/Example #3/NoInviteExampleViewController.swift
+++ b/CustomInvitationSample/CustomInvitationSample/Example #3/NoInviteExampleViewController.swift
@@ -7,24 +7,39 @@
 //
 
 import Foundation
+import EXPCore
+import EXPSurveyManagement
 
-class NoInviteExampleViewController : InviteExampleViewController, EXPInviteHandler  {
+class NoInviteExampleViewController : InviteExampleViewController, EXPInviteHandler, VerintDelegate  {
+
+    @IBOutlet weak var showSurveyButton: UIButton!
 
     // MARK: UIViewController
 
     override func viewDidLoad() {
         self.inviteHandler = self
-        EXPPredictive.setInviteHandler(self.inviteHandler)
+        self.showSurveyButton.isUserInteractionEnabled = false
+        EXPCore.setDelegate(self)
+        EXPCore.start(withAppId: "telekomcfmkeymeinmagentaapp9test")
+        
     }
 
     // MARK: Outlets
 
     @IBAction func showInvitelessSurvey(_ sender: Any) {
-        EXPPredictive.checkIfEligibleForSurvey()
+        SurveyManagement.incrementSignificantEventCount(withKey: "mma-nps")
+        SurveyManagement.checkIfEligibleForSurvey()
     }
 
     @IBAction func resetState(_ sender: Any) {
         EXPCore.resetState()
+    }
+    
+    // MARK: VerintDelegate
+    
+    func didStartSDK() {
+        self.showSurveyButton.isUserInteractionEnabled = true
+        EXPPredictive.setInviteHandler(self.inviteHandler)
     }
 
     // MARK: EXPInviteHandler

--- a/CustomInvitationSample/CustomInvitationSample/InviteExampleViewController.m
+++ b/CustomInvitationSample/CustomInvitationSample/InviteExampleViewController.m
@@ -14,7 +14,7 @@
     // reset state so that we always show the example; a
     // normal production application should not reset state
     // every time -- you *want* to track the user's state!
-    [EXPCore resetState];
+    //[EXPCore resetState]; // Disable for testing
 }
 
 - (void)viewWillDisappear:(BOOL)animated {


### PR DESCRIPTION
This draft PR demonstrates usage of `startWithAppId` and the `VerintDelegate` to show a no-invite custom survey in the Verint SDK.

Please consider that this is a draft PR created to demonstrate something specific, so the flow is also necessarily specific. To run this example:

1. Start the `CustomInvitationSample`
2. Tap "No Invite Survey Example"
3. At this point the SDK will start in the manner described below
4. Once started, you can tap "Show survey without invite" to demonstrate the functionality
5. The state of the SDK will reset every time you restart the app

Note a few things:

1. Since `startWithAppId` makes a network call, we need to wait until it was completed before we can do anything else
6. We do that by implementing the `didStartSDK` method from the `VerintDelegate` which we set using `EXPCore.setDelegate(self)` before calling `start`
7. The "Show invite" button will be disabled until that delegate method has been executed
8. At that point you can proceed as normal