### PR TITLE
VOC-66416: Added LD_RUNPATH_SEARCH_PATHS to fix the Library not loaded: @rpath/... crash

### DIFF
--- a/BasicSample/BasicSample.xcodeproj/project.pbxproj
+++ b/BasicSample/BasicSample.xcodeproj/project.pbxproj
@@ -252,6 +252,10 @@
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "BasicSample/BasicSample-Prefix.pch";
 				INFOPLIST_FILE = "BasicSample/BasicSample-Info.plist";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
 				LIBRARY_SEARCH_PATHS = (
 					"$(inherited)",
 					"\"$(SRCROOT)/BasicSample\"",
@@ -373,6 +377,10 @@
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "BasicSample/BasicSample-Prefix.pch";
 				INFOPLIST_FILE = "BasicSample/BasicSample-Info.plist";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
 				LIBRARY_SEARCH_PATHS = (
 					"$(inherited)",
 					"\"$(SRCROOT)/BasicSample\"",
@@ -401,6 +409,10 @@
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "BasicSample/BasicSample-Prefix.pch";
 				INFOPLIST_FILE = "BasicSample/BasicSample-Info.plist";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
 				LIBRARY_SEARCH_PATHS = (
 					"$(inherited)",
 					"\"$(SRCROOT)/BasicSample\"",


### PR DESCRIPTION
Build: https://app.bitrise.io/app/0c2f7f72062d233c/build/40aa0986-9143-4214-9161-09897660f57f

```
Root cause:

The crash is a DYLD launch-time abort (EXC_CRASH / SIGABRT, bug_type 309), not an app logic crash. The termination reason says it all:

@rpath is a placeholder that the linker resolves at runtime using LC_RPATH load commands embedded in the binary. Because LD_RUNPATH_SEARCH_PATHS was absent from all three BasicSample target build configurations (Debug, Release, Release w/ symbols), the linker wrote zero LC_RPATH entries into the binary, so dyld had no path to search and killed the process immediately.

Why it only fails on AdHoc/BrowserStack

When running locally from Xcode, the IDE injects DYLD_FRAMEWORK_PATH as a launch environment variable pointing to the build's framework staging directory — this sidesteps the @rpath mechanism entirely. On a signed device build (AdHoc/App Store), Apple's sandbox strips all DYLD_* environment variables, so @rpath is the only resolution path. With no LC_RPATH entries, it fails.

Why other samples (e.g. AdvancedSample) worked

AdvancedSample already had LD_RUNPATH_SEARCH_PATHS = ("$(inherited)", "@executable_path/Frameworks") in both its Debug and Release target configurations. BasicSample was simply never updated when the SDK was migrated to an @rpath-based XCFramework.

Fix applied

Added LD_RUNPATH_SEARCH_PATHS = ("$(inherited)", "@executable_path/Frameworks") to all three target-level build configurations in [project.pbxproj](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html). This tells the linker to write an LC_RPATH pointing to <app bundle>/Frameworks/, where the embedded framework is copied at archive time.
```